### PR TITLE
fix/ME-49-Update-new-validator-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "modules": "dist/index",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint **/*.ts",
+    "lint": "eslint \"{src,__tests__}/**/*.ts\"",
     "lint:fix": "eslint **/*.ts --fix",
     "npm:publish": "npm publish --access public",
     "prenpm:publish": "npm run lint && npm run build",


### PR DESCRIPTION
Se actualizo el package.json para que al correr `run lint`, no se revisen los archivos de la carpeta **dist** y se revisen unicamente las carpetas src y _tests_ .
