### PR TITLE
Bug/me-50-share-req-schema-is-missing-iss-property

### DIFF
--- a/__tests__/shareRequest.v1.test.ts
+++ b/__tests__/shareRequest.v1.test.ts
@@ -11,7 +11,7 @@ const valid = {
     verifiable: {
       semillaSembFamiliar: {
         essential: true,
-        iss: [
+        issuers: [
           {
             did: 'did:web:idverifier.claims',
             url: 'https://idverifier.example',
@@ -22,7 +22,7 @@ const valid = {
 
       semillaSancorSalud: {
         essential: true,
-        iss: [
+        issuers: [
           {
             did: 'did:web:idverifier.claims',
             url: 'https://idverifier.example',
@@ -33,7 +33,7 @@ const valid = {
 
       mobilePhone: {
         essential: true,
-        iss: [
+        issuers: [
           {
             did: 'did:web:idverifier.claims',
             url: 'https://idverifier.example',
@@ -64,7 +64,7 @@ describe('shareRequest.v1.test', () => {
     claims: {
       verifiable: {
         emailMain: {
-          iss: [
+          issuers: [
             {
               did: 'did:web:uport.claims',
               url: 'https://uport.claims/email',
@@ -78,7 +78,7 @@ describe('shareRequest.v1.test', () => {
         },
         nationalId: {
           essential: true,
-          iss: [
+          issuers: [
             {
               did: 'did:web:idverifier.claims',
               url: 'https://idverifier.example',
@@ -116,7 +116,7 @@ describe('shareRequest.v1.test', () => {
     claims: {
       verifiable: {
         emailMain: {
-          iss: [
+          issuers: [
             {
               did: 'did:web:uport.claims',
               url: 'https://uport.claims/email',
@@ -130,7 +130,7 @@ describe('shareRequest.v1.test', () => {
         },
         nationalId: {
           essential: true,
-          iss: [
+          issuers: [
             {
               did: 'did:web:idverifier.claims',
               url: 'https://idverifier.example',
@@ -168,7 +168,7 @@ describe('shareRequest.v1.test', () => {
     claims: {
       verifiable: {
         emailMain: {
-          iss: [
+          issuers: [
             {
               did: 'did:web:uport.claims',
               url: 'https://uport.claims/email',
@@ -182,7 +182,7 @@ describe('shareRequest.v1.test', () => {
         },
         nationalId: {
           essential: true,
-          iss: [
+          issuers: [
             {
               did: 'did:web:idverifier.claims',
               url: 'https://idverifier.example',
@@ -220,7 +220,7 @@ describe('shareRequest.v1.test', () => {
     claims: {
       verifiable: {
         emailMain: {
-          iss: [
+          issuers: [
             {
               did: 'did:web:uport.claims',
               url: 'https://uport.claims/email',
@@ -234,7 +234,7 @@ describe('shareRequest.v1.test', () => {
         },
         nationalId: {
           essential: true,
-          iss: [
+          issuers: [
             {
               did: 'did:web:idverifier.claims',
               url: 'https://idverifier.example',
@@ -273,7 +273,7 @@ describe('shareRequest.v1.test', () => {
     claims: {
       verifiable: {
         emailMain: {
-          iss: [
+          issuers: [
             {
               did: 3,
               url: 'https://uport.claims/email',
@@ -287,7 +287,7 @@ describe('shareRequest.v1.test', () => {
         },
         nationalId: {
           essential: true,
-          iss: [
+          issuers: [
             {
               did: 'did:web:idverifier.claims',
               url: 'https://idverifier.example',
@@ -312,10 +312,10 @@ describe('shareRequest.v1.test', () => {
     expect(result.status).toBe(false);
     expect(result.errors[0].keyword).toBe('type');
     expect(result.errors[0].dataPath).toBe(
-      '.claims.verifiable.emailMain.iss[0].did',
+      '.claims.verifiable.emailMain.issuers[0].did',
     );
     expect(result.errors[0].schemaPath).toBe(
-      '#/properties/claims/properties/verifiable/properties/emailMain/properties/iss/items/0/properties/did/type',
+      '#/properties/claims/properties/verifiable/properties/emailMain/properties/issuers/items/0/properties/did/type',
     );
     expect(result.errors[0].params.type).toBe('string');
     expect(result.errors[0].message).toBe('should be string');
@@ -329,7 +329,7 @@ describe('shareRequest.v1.test', () => {
     claims: {
       verifiable: {
         emailMain: {
-          iss: [
+          issuers: [
             {
               did: 'did:web:uport.claims',
               url: 7,
@@ -342,7 +342,7 @@ describe('shareRequest.v1.test', () => {
         },
         nationalId: {
           essential: true,
-          iss: [
+          issuers: [
             {
               did: 'did:web:idverifier.claims',
               url: 'https://idverifier.example',
@@ -367,10 +367,10 @@ describe('shareRequest.v1.test', () => {
     expect(result.status).toBe(false);
     expect(result.errors[0].keyword).toBe('type');
     expect(result.errors[0].dataPath).toBe(
-      '.claims.verifiable.emailMain.iss[0].url',
+      '.claims.verifiable.emailMain.issuers[0].url',
     );
     expect(result.errors[0].schemaPath).toBe(
-      '#/properties/claims/properties/verifiable/properties/emailMain/properties/iss/items/0/properties/url/type',
+      '#/properties/claims/properties/verifiable/properties/emailMain/properties/issuers/items/0/properties/url/type',
     );
     expect(result.errors[0].params.type).toBe('string');
     expect(result.errors[0].message).toBe('should be string');
@@ -384,7 +384,7 @@ describe('shareRequest.v1.test', () => {
     claims: {
       verifiable: {
         emailMain: {
-          iss: [
+          issuers: [
             {
               did: 'did:web:uport.claims',
               url: 'https://uport.claims/email',
@@ -398,7 +398,7 @@ describe('shareRequest.v1.test', () => {
         },
         nationalId: {
           essential: true,
-          iss: [
+          issuers: [
             {
               did: 'did:web:idverifier.claims',
               url: 'https://idverifier.example',

--- a/src/messages/shareRequest-schema.ts
+++ b/src/messages/shareRequest-schema.ts
@@ -10,7 +10,7 @@ const verifiableProperties = types.reduce((_acc: any, valor: string) => {
       essential: {
         type: 'boolean',
       },
-      iss: {
+      issuers: {
         type: 'array',
         items: [
           {
@@ -31,7 +31,7 @@ const verifiableProperties = types.reduce((_acc: any, valor: string) => {
         type: 'string',
       },
     },
-    required: ['iss', 'reason'],
+    required: ['issuers', 'reason'],
   };
   return _acc;
 }, {});

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -26,3 +26,22 @@ export function validateCredential(
     errors: null,
   };
 }
+
+export function validateSchema(
+  schema: object,
+  body: object,
+): ValidateCredentialType {
+  const ajv = new Ajv();
+  const validate = ajv.compile(schema);
+  const valid = validate(body);
+  if (!valid) {
+    return {
+      status: false,
+      errors: validate.errors,
+    };
+  }
+  return {
+    status: true,
+    errors: null,
+  };
+}


### PR DESCRIPTION
- Se actualizo el schema de **share req** para que tenga la prop issuers en vez de iss. 
- Se actualizaron los tests de share req
- Se agregó una funcion en `src/validator.ts` que recibe un objeto como parametro, en vez de un jwt. (Esta función es de utilidad para la tarea _ME-7_)